### PR TITLE
Add new configuration option: pandoc_csl_default_lang

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,8 +3,8 @@
 
 * Make more pandoc-related options available through the web config interface
 * Make (scalar) pandoc yaml meta block variables visible to templates
-* Avoid 'Use of unitialized value...' warning when the 'pandoc_math' option is not present in the *.setup file
-
+* Avoid 'Use of uninitialized value...' warning when the `pandoc_math` option is not present in the `*.setup` file
+* Add new configuration option affecting citations processing: `pandoc_csl_default_lang`
 
 0.2 (2015-12-18)
 ================

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ These settings have no effect unless you have activated the `page.tmpl` file whi
 
 * `pandoc_csl` (string): CSL file to use by default to format in-line references and the list of references. If this is empty, the default Chicago author-year format will be used, unless you specify a CSL file using `csl` in a YAML meta-block in the page itself.
 
+* `pandoc_csl_default_lang` (string): Language code to use by default during citations processing, unless something different is specified in the YAML meta block (using either of the keys `lang` or `locale`). Language codes follow [RFC 1766](https://www.ietf.org/rfc/rfc1766.txt) and are typically either two letters (e.g. `en` for English) or two letters followed by a hyphen and a refinement code (e.g. `en-GB` for British English). If no language code is configured here, pandoc-citeproc uses the default language of the preferred CSL file, or US English (`en-US`) if it specifies no default language. Underscore may be used instead of a hyphen in language codes, so `en-GB` and `en_GB` are equivalent. Pandoc-citeproc [supports](https://github.com/jgm/pandoc-citeproc/tree/master/locales) almost 50 major European and Asian languages.
+
 ### Output tweaking
 
 * `pandoc_smart` (boolean): Whether smart quotes and other typographic niceties are enabled.

--- a/pandoc.pm
+++ b/pandoc.pm
@@ -209,6 +209,13 @@ sub getsetup () {
         safe => 1,
         rebuild => 1,
     },
+    pandoc_csl_default_lang => {
+        type => "string",
+        example => "",
+        description => "Default language code (RFC 1766) for citations processing",
+        safe => 1,
+        rebuild => 1,
+    },
     pandoc_filters => {
         type => "string",
         example => "",
@@ -331,7 +338,8 @@ sub htmlize ($@) {
     }
 
     my %scalar_meta = map { ($_=>undef) } qw(
-        title date bibliography csl subtitle abstract summary description version);
+        title date bibliography csl subtitle abstract summary
+        description version lang locale);
     my %list_meta = map { ($_=>[]) } qw/author references/;
     my $have_bibl = 0;
     foreach my $k (keys %scalar_meta) {
@@ -382,7 +390,13 @@ sub htmlize ($@) {
             last;
         }
     }
-
+    # If a default CSL language is specified, add that to args,
+    # (unless it is overridden by meta)
+    unless ($scalar_meta{lang} || $scalar_meta{locale}) {
+        if ($config{pandoc_csl_default_lang}) {
+            push @args, "--metadata=lang:".$config{pandoc_csl_default_lang};
+        }
+    }
     # Turn on the pandoc-citeproc filter if either global bibliography,
     # local bibliography or a 'references' key in Meta is present.
     if ($have_bibl) {


### PR DESCRIPTION
The new configuration option `pandoc_csl_default_lang` sets the default language to be used for citations processing. Resolves issue #9.