### PR TITLE
Correct capitalization of meta

### DIFF
--- a/pandoc.pm
+++ b/pandoc.pm
@@ -435,7 +435,7 @@ sub htmlize ($@) {
     my $meta = undef;
     my $decoded_json = decode_json($json_content);
     # The representation of the meta block changed in pandoc version 1.18
-    if (ref $decoded_json eq 'HASH' && $decoded_json->{'Meta'}) {
+    if (ref $decoded_json eq 'HASH' && $decoded_json->{'meta'}) {
         $meta = $decoded_json->{'meta'} || {}; # post-1.18 version
     } elsif (ref $decoded_json eq 'ARRAY') {
         $meta = $decoded_json->[0]->{'unMeta'} || {}; # pre-1.18 version


### PR DESCRIPTION
This is needed at least for Pandoc 2.5

PR #19 didn't completely work for me with the latest pandoc, this patch allows it to process meta tags correctly.